### PR TITLE
Added switches: --unicode-keys, --assume-one-page, --image-file-extension [REVERTED]

### DIFF
--- a/bin/bmfont2json.js
+++ b/bin/bmfont2json.js
@@ -1,25 +1,117 @@
 #!/usr/bin/env node
 
-var argv = require('yargs')
-				.usage('Usage: file [options]')
-				.alias('o', 'output')
-				.alias('p', 'pretty')
-				.describe('o', 'the output path')
-				.describe('p', 'pretty-print the JSON output')
-				.demand(1)
-				.argv;
+'use strict';
 
-var parse = require('../');
-var fs = require('fs');
+const fs = require('fs');
+const parse = require('../');
 
-fs.readFile( argv._[0], function(err, data) {
-	if (err)
-		throw "Could not open "+argv._[0]+"\n"+err;
+// Define command line usage
+const argv = require('yargs')
+		.usage('Usage: file [options]')
+		.demand(1)
+		.help('help').alias('help', 'h')
+		.options({
+			'output': {
+				alias: 'o',
+				describe: 'The output path',
+				requiresArg: true,
+				string: true
+			},
+			'unicode-keys': {
+				alias: 'u',
+				describe: 'Use Unicode characters as keys in "object.chars" and ' +
+						'"object.kernings". For the latter, ".second" is used as an outer key ' +
+						'and ".first" as an inner key'
+			},
+			'assume-one-page': {
+				alias: '1',
+				describe: 'Replace "object.pages" with "object.imageFileName" and remove the ' +
+						'number suffix'
+			},
+			'image-file-extension': {
+				alias: 'x',
+				describe: 'Change the extension of the image file names to the provided one',
+				requiresArg: true,
+				string: true
+			},
+			'pretty': {
+				alias: 'p',
+				describe: 'Pretty-print the JSON output'
+			}
+		})
+		.argv;
 
-	var obj = parse(data);
+// Validate image file extension
+if (argv.imageFileExtension) {
+	let newExtension = argv.imageFileExtension.replace(/^\./, '');
+	if (!/^\w+$/.test(newExtension)) {
+		throw `Invalid image file extension: ${argv.imageFileExtension}`;
+	}
+	argv.imageFileExtension = newExtension;
+}
 
-	var jsonOut = JSON.stringify(obj, undefined, argv.p ? 2 : undefined);
+// Convert the file
+fs.readFile(argv._[0], function(err, data) {
+	if (err) {
+		throw `Could not open "${argv._[0]}"\n${err}`;
+	}
 
-	var writer = argv.o ? fs.createWriteStream(argv.o) : process.stdout;
-	writer.write(jsonOut+ (argv.p?'\n':''));
-})
+	// Do the actual conversion
+	let object = parse(data);
+
+	if (argv.assumeOnePage) {
+		object.imageFileName = object.pages[0].replace(/_0(?=\.\w+$)/, '');
+		delete object.pages;
+		for (let char of object.chars) {
+			delete char.page;
+		}
+		delete object.common.pages;
+	}
+
+	if (argv.imageFileExtension) {
+		let changeExtension = function(filename) {
+			return filename.replace(/(.\.)\w+$/, `$1${argv.imageFileExtension}`);
+		}
+		if (argv.assumeOnePage) {
+			object.imageFileName = changeExtension(object.imageFileName);
+		} else {
+			for (let i = 0; i < object.pages.length; i++) {
+				object.pages[i] = changeExtension(object.pages[i]);
+			}
+		}
+	}
+
+	if (argv.unicodeKeys) {
+		let newChars = { };
+		for (let char of object.chars) {
+			newChars[String.fromCodePoint(char.id)] = char;
+			delete char.id;
+		}
+		object.chars = newChars;
+
+		let newKernings = { };
+		for (let kerning of object.kernings) {
+			let firstChar = String.fromCodePoint(kerning.first);
+			let secondChar = String.fromCodePoint(kerning.second);
+			let newKerning = newKernings[secondChar];
+			if (!newKerning) {
+				newKerning = newKernings[secondChar] = { };
+			}
+			newKerning[firstChar] = kerning;
+			delete kerning.first;
+			delete kerning.second;
+		}
+		object.kernings = newKernings;
+	}
+
+	// Create big JSON string from JavaScript object
+	let jsonOut = JSON.stringify(object, undefined, argv.pretty ? '\t' : undefined);
+	jsonOut = jsonOut.replace(/[\u0080-\uffff]/g, function(match) {
+		// Escape all non-ASCII characters
+		return '\\u' + `00${ match.charCodeAt(0).toString(16) }`.slice(-4);
+	});
+
+	// Write file (or to stdout)
+	let writer = argv.output ? fs.createWriteStream(argv.output) : process.stdout;
+	writer.write(jsonOut + (argv.pretty ? '\n' : ''));
+});

--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
-var TXT = 'txt',
-    XML = 'xml';
+'use strict';
 
-var parseAscii = require('parse-bmfont-ascii');
-var parseXML = require('parse-bmfont-xml');
+const parseAscii = require('parse-bmfont-ascii');
+const parseXML = require('parse-bmfont-xml');
+
+const TXT = 'txt';
+const XML = 'xml';
 
 /**
  * Parses a string (or Node Buffer) that is either XML data (with a root <font> element),
  * or TXT data (following Bitmap Font spec: http://www.angelcode.com/products/bmfont/doc/file_format.html).
  *
  * The output looks something like the following JSON. It tries to stay true to the BMFont spec.
- * 
+ *
  * ```json
  * {
  *      pages: [
- *          "sheet_0.png", 
+ *          "sheet_0.png",
  *          "sheet_1.png"
  *      ],
  *      chars: [
@@ -36,28 +38,27 @@ var parseXML = require('parse-bmfont-xml');
  */
 function parse(data, format) {
     if (!data)
-        throw "no data provided";
+        throw "No data provided";
 
     data = data.toString().trim();
-    
+
     if (!format) {
         if (data.substring(0,4) === 'info')
             format = TXT;
         else if (data.charAt(0) === '<')
             format = XML;
         else
-            throw "malformed XML/TXT bitmap font file";
+            throw "Malformed .xml/.txt bitmap font file";
     }
-    
+
     if (format !== XML && format !== TXT)
-        throw "only xml and txt formats are currently supported";
-    
+        throw "Only .xml and .txt formats are currently supported";
+
     if (format === TXT) {
         return parseAscii(data);
     } else {
         return parseXML(data);
     }
 }
-
 
 module.exports = parse;

--- a/package.json
+++ b/package.json
@@ -1,42 +1,44 @@
 {
-  "name": "bmfont2json",
-  "version": "0.1.9",
-  "description": "converts BMFont TXT and XML files to JSON",
-  "main": "index.js",
-  "dependencies": {
-    "parse-bmfont-ascii": "^1.0.0",
-    "parse-bmfont-xml": "^1.0.1",
-    "yargs": "^1.2.2"
-  },
-  "devDependencies": {
-    "tape": "^3.5.0"
-  },
-  "bin": {
-    "bmfont2json": "./bin/bmfont2json.js"
-  },
-  "scripts": {
-    "test": "node test"
-  },
-  "author": "Matt DesLauriers",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mattdesl/bmfont2json.git"
-  },
-  "keywords": [
-    "bmfont",
-    "bitmap",
-    "fonts",
-    "json",
-    "xml",
-    "txt",
-    "angelcode",
-    "angel",
-    "code",
-    "text"
-  ],
-  "bugs": {
-    "url": "https://github.com/mattdesl/bmfont2json/issues"
-  },
-  "homepage": "https://github.com/mattdesl/bmfont2json"
+	"name": "bmfont2json",
+	"version": "0.2.0",
+	"description": "Converts BMFont .txt and .xml files to JSON",
+	"main": "index.js",
+	"dependencies": {
+		"parse-bmfont-ascii": "^1.0.0",
+		"parse-bmfont-xml": "^1.0.1",
+		"yargs": "^1.2.2"
+	},
+	"devDependencies": {
+		"tape": "^3.5.0"
+	},
+	"bin": {
+		"bmfont2json": "./bin/bmfont2json.js"
+	},
+	"scripts": {
+		"test": "node test"
+	},
+	"author": "Matt DesLauriers",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/mattdesl/bmfont2json.git"
+	},
+	"keywords": [
+		"bmfont",
+		"bitmap",
+		"font",
+		"fonts",
+		"json",
+		"xml",
+		"txt",
+		"convert",
+		"angelcode",
+		"angel",
+		"code",
+		"text"
+	],
+	"bugs": {
+		"url": "https://github.com/mattdesl/bmfont2json/issues"
+	},
+	"homepage": "https://github.com/mattdesl/bmfont2json"
 }

--- a/test.js
+++ b/test.js
@@ -1,21 +1,23 @@
-var fs = require('fs');
-var path = require('path');
-var folders = [ 'xml', 'txt', 'multipage' ];
-var nexa = 'Nexa Light-32.fnt'
+'use strict';
 
-var paths = folders.map(function(dir) {
+const fs = require('fs');
+const path = require('path');
+const folders = [ 'xml', 'txt', 'multipage' ];
+const nexa = 'Nexa Light-32.fnt'
+
+let paths = folders.map(function(dir) {
     return path.join(__dirname, 'test-files', dir, nexa);
 });
 
-var test = require('tape');
-var bmfont = require('./');
-var expected = require('./test-files/txt/Test.json');
+const test = require('tape');
+const bmfont = require('./');
+const expected = require('./test-files/txt/Test.json');
 
 test('should parse fonts', function(t) {
   paths.forEach(function(p) {
-      var f = fs.readFileSync(p);
+      let f = fs.readFileSync(p);
 
-      var result = bmfont(f);
+      let result = bmfont(f);
       t.equal(result.info.face, 'Nexa Light', 'face parsed');
       t.equal(result.chars.length, 96, 'chars parsed');
       t.equal(result.kernings.length, 487, 'kernings parsed');
@@ -25,10 +27,10 @@ test('should parse fonts', function(t) {
 });
 
 test('should match expected', function(t) {
-  var p = path.join(__dirname, 'test-files', 'txt', nexa);
-  var f = fs.readFileSync(p);
+  let p = path.join(__dirname, 'test-files', 'txt', nexa);
+  let f = fs.readFileSync(p);
 
-  var result = bmfont(f);
+  let result = bmfont(f);
   t.deepEqual(result, expected, 'matches JSON');
   t.end();
 });


### PR DESCRIPTION
Hello,

I hope you don't mind that I restructured some code in order to add some switches. I also increased the version number.
## Copied from the code

`--unicode-keys` [makes the data easier to process]:

Use Unicode characters as keys in "object.chars" and "object.kernings". For the latter, ".second" is used as an outer key and ".first" as an inner key

`--assume-one-page` [I don't unterstand why I should ever use more than one; makes accessing the filename easier]:

Replace "object.pages" with "object.imageFileName" and remove the number suffix

`--image-file-extension` [I convert my files]:

Change the extension of the image file names to the provided one
